### PR TITLE
Guard for alternative identifier @types

### DIFF
--- a/client/public/src/models/WorkModel.js
+++ b/client/public/src/models/WorkModel.js
@@ -185,7 +185,7 @@ class WorkModel extends BaseModel {
           author.identifiers = [author.identifiers]
         }
         for (let id of author.identifiers) {
-          if (this.grpsWithLinks.includes(id['@type'])) {
+          if (this.grpsWithLinks.includes(id['@type']) && id['@id'].match("^"+this.service.jsonContext+":")) {
             let authorId = id['@id'].replace(this.service.jsonContext + ":", "");
             author.apiEndpoint = id['@id'];
             author.href = this.urlAuthor + authorId;


### PR DESCRIPTION
 I didn't check this code, but I suspect this prevents the identifier from being saved on some works